### PR TITLE
Implement budget variance tool

### DIFF
--- a/app/analysis/variance.py
+++ b/app/analysis/variance.py
@@ -1,0 +1,107 @@
+"""Budget vs actual variance computation.
+
+Purpose: MCP tool to reconcile budgets and actuals at the account level.
+Deployment: part of FastMCP server or standalone CLI.
+Test: ``pytest tests/analysis/test_variance.py``
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+from fastmcp.contrib.mcp_mixin import mcp_tool
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_pct(numerator: float, denominator: float) -> float:
+    """Return percentage safely, avoiding divide-by-zero."""
+    if denominator == 0:
+        return 0.0
+    return round((numerator / denominator) * 100, 2)
+
+
+@mcp_tool("reconcileBudgetVsActual")
+def reconcile_budget(data: Dict) -> Dict:
+    """Compute account-level variance between budgets and actuals.
+
+    ``data`` must contain lists under ``budgets`` and ``actuals`` with
+    ``account`` identifiers and numeric amounts ``amount_planned`` and
+    ``amount_actual`` respectively.
+    """
+    if not isinstance(data, dict):
+        raise TypeError("Input must be a dict")
+
+    budgets: List[Dict] = data.get("budgets") or []
+    actuals: List[Dict] = data.get("actuals") or []
+
+    if not isinstance(budgets, list) or not isinstance(actuals, list):
+        raise ValueError("'budgets' and 'actuals' must be lists")
+
+    logger.info("Reconciling %d budget rows and %d actual rows", len(budgets), len(actuals))
+
+    budget_map: Dict[str, Dict] = {}
+    for b in budgets:
+        acct = b.get("account")
+        if acct is None:
+            raise ValueError("Budget row missing 'account'")
+        if "amount_planned" not in b:
+            raise ValueError("Budget row missing 'amount_planned'")
+        budget_map[acct] = b
+
+    actual_totals: Dict[str, float] = {}
+    for a in actuals:
+        acct = a.get("account")
+        if acct is None:
+            raise ValueError("Actual row missing 'account'")
+        if "amount_actual" not in a:
+            raise ValueError("Actual row missing 'amount_actual'")
+        actual_totals[acct] = actual_totals.get(acct, 0.0) + float(a.get("amount_actual", 0.0))
+
+    variance_rows: List[Dict] = []
+
+    processed_accounts = set()
+
+    for acct, b in budget_map.items():
+        planned = float(b.get("amount_planned", 0.0))
+        actual = actual_totals.get(acct, 0.0)
+        variance = actual - planned
+        pct = _safe_pct(variance, planned)
+        flag = "ok"
+        if variance > 0:
+            flag = "over"
+        elif variance < 0:
+            flag = "under"
+
+        variance_rows.append(
+            {
+                "account": acct,
+                "variance_amount": variance,
+                "variance_pct": pct,
+                "flag": flag,
+            }
+        )
+        processed_accounts.add(acct)
+
+    # Handle actuals without corresponding budget
+    for acct, actual in actual_totals.items():
+        if acct in processed_accounts:
+            continue
+        variance_rows.append(
+            {
+                "account": acct,
+                "variance_amount": actual,
+                "variance_pct": 0.0,
+                "flag": "over",
+            }
+        )
+
+    total_variance = sum(v["variance_amount"] for v in variance_rows)
+    logger.info(
+        "Computed variance for %d accounts (total %.2f)",
+        len(variance_rows),
+        total_variance,
+    )
+
+    return {"variance": variance_rows}

--- a/samples/mock_variance_input.json
+++ b/samples/mock_variance_input.json
@@ -1,0 +1,12 @@
+{
+  "budgets": [
+    {"account": "A", "amount_planned": 10000},
+    {"account": "B", "amount_planned": 20000},
+    {"account": "C", "amount_planned": 0}
+  ],
+  "actuals": [
+    {"account": "A", "amount_actual": 9000},
+    {"account": "B", "amount_actual": 22000},
+    {"account": "D", "amount_actual": 5000}
+  ]
+}

--- a/tests/analysis/test_variance.py
+++ b/tests/analysis/test_variance.py
@@ -1,0 +1,33 @@
+"""Tests for reconcile_budget variance computation."""
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.analysis.variance import reconcile_budget
+
+
+def test_reconcile_budget() -> None:
+    sample_path = pathlib.Path(__file__).resolve().parents[2] / "samples" / "mock_variance_input.json"
+    with open(sample_path) as f:
+        data = json.load(f)
+
+    result = reconcile_budget(data)
+
+    by_account = {v["account"]: v for v in result["variance"]}
+
+    assert by_account["A"]["variance_amount"] == -1000
+    assert by_account["A"]["variance_pct"] == -10.0
+    assert by_account["A"]["flag"] == "under"
+
+    assert by_account["B"]["variance_amount"] == 2000
+    assert by_account["B"]["variance_pct"] == 10.0
+    assert by_account["B"]["flag"] == "over"
+
+    assert by_account["C"]["variance_amount"] == 0
+    assert by_account["C"]["flag"] == "ok"
+
+    assert by_account["D"]["variance_amount"] == 5000
+    assert by_account["D"]["flag"] == "over"


### PR DESCRIPTION
## Summary
- add variance analysis module with reconcileBudgetVsActual tool
- provide mock variance data for tests
- test variance calculation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b592533c48326a181fa347e5b0388