### PR TITLE
Implement argument support & prompt workflows

### DIFF
--- a/app/prompts/variance_dm.yaml
+++ b/app/prompts/variance_dm.yaml
@@ -1,0 +1,12 @@
+id: variance_dm
+title: "DM Implications"
+description: "Explain variance implications for deputy minister"
+arguments:
+  - name: summary
+    description: "Variance summary text"
+    type: string
+    required: true
+user: |
+  The deputy minister needs a plain-language explanation of the following:
+  {summary}
+  Outline the key impacts on operations.

--- a/app/prompts/variance_summary.yaml
+++ b/app/prompts/variance_summary.yaml
@@ -4,6 +4,7 @@ description: "Draft a narrative summary of budget variance"
 arguments:
   - name: data
     description: "Budget vs actual data table"
+    type: string
     required: true
 system: |
   You are a helpful financial analyst assistant. Summarize key insights for an executive report.

--- a/app/prompts/variance_workflow.yaml
+++ b/app/prompts/variance_workflow.yaml
@@ -1,0 +1,15 @@
+id: variance_workflow
+title: "Variance DM Workflow"
+description: "Summarize variance data then craft DM explanation"
+arguments:
+  - name: data
+    description: "Budget vs actual data"
+    type: string
+    required: true
+steps:
+  - prompt: variance_summary
+    arguments:
+      data: "{data}"
+  - prompt: variance_dm
+    arguments:
+      summary: "Summary: {data}"

--- a/app/server.py
+++ b/app/server.py
@@ -38,6 +38,18 @@ def prompt_variance_summary(data: dict):
     return load_prompt_template("variance_summary", data=data)
 
 
+@mcp.prompt("variance_dm", description="Explain variance implications for DM")
+def prompt_variance_dm(summary: str):
+    """Render the deputy minister explanation prompt."""
+    return load_prompt_template("variance_dm", summary=summary)
+
+
+@mcp.prompt("variance_workflow", description="Multi-step variance briefing")
+def prompt_variance_workflow(data: str):
+    """Run the variance workflow chain."""
+    return load_prompt_template("variance_workflow", data=data)
+
+
 @mcp.resource("config://azure_sql", name="Azure SQL Config", mime_type="text/yaml")
 def get_azure_sql_config() -> str:
     """Return the Azure SQL configuration YAML."""

--- a/tests/prompts/test_prompt_chain.py
+++ b/tests/prompts/test_prompt_chain.py
@@ -1,0 +1,19 @@
+"""Tests for PromptChain and argument substitution."""
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.prompts.load import load_prompt_template, PromptChain, load_prompt
+
+
+def test_argument_injection() -> None:
+    msgs = load_prompt_template("variance_dm", summary="Test summary")
+    assert any("Test summary" in m.content.text for m in msgs)
+
+
+def test_chain_run() -> None:
+    data = "Sample variance"
+    chain = PromptChain(load_prompt("variance_workflow")["steps"])
+    msgs = chain.run(data=data)
+    assert any("Sample variance" in m.content.text for m in msgs)

--- a/tests/prompts/test_prompts_api.py
+++ b/tests/prompts/test_prompts_api.py
@@ -28,3 +28,11 @@ def test_prompts_get() -> None:
     assert result.description.startswith("Draft")
     assert result.messages[0].role == "user"
     assert "dept'" in result.messages[-1].content.text
+
+    chain = asyncio.run(
+        mcp._mcp_get_prompt(
+            "variance_workflow",
+            {"data": '{"dept": "A", "variance": "over"}'}
+        )
+    )
+    assert len(chain.messages) > 2


### PR DESCRIPTION
## Summary
- implement `PromptChain` for multi-step YAML prompts
- inject arguments when loading prompt templates
- add new prompts `variance_dm` and `variance_workflow`
- register new prompts in the server
- expand tests for argument injection and workflow chaining

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b5f4a7d4083269a62b2ce5947593d