### PR TITLE
Task008: register tools and metadata

### DIFF
--- a/app/analysis/variance.py
+++ b/app/analysis/variance.py
@@ -8,7 +8,7 @@ Test: ``pytest tests/analysis/test_variance.py``
 from __future__ import annotations
 
 import logging
-from typing import Dict, List
+from typing import List
 
 from fastmcp.contrib.mcp_mixin import mcp_tool
 
@@ -22,8 +22,12 @@ def _safe_pct(numerator: float, denominator: float) -> float:
     return round((numerator / denominator) * 100, 2)
 
 
-@mcp_tool("reconcileBudgetVsActual")
-def reconcile_budget(data: Dict) -> Dict:
+@mcp_tool(
+    name="reconcileBudgetVsActual",
+    description="Compute variances between planned and actual amounts",
+    annotations={"readOnlyHint": True},
+)
+def reconcile_budget(data: dict) -> dict:
     """Compute account-level variance between budgets and actuals.
 
     ``data`` must contain lists under ``budgets`` and ``actuals`` with
@@ -33,15 +37,15 @@ def reconcile_budget(data: Dict) -> Dict:
     if not isinstance(data, dict):
         raise TypeError("Input must be a dict")
 
-    budgets: List[Dict] = data.get("budgets") or []
-    actuals: List[Dict] = data.get("actuals") or []
+    budgets: List[dict] = data.get("budgets") or []
+    actuals: List[dict] = data.get("actuals") or []
 
     if not isinstance(budgets, list) or not isinstance(actuals, list):
         raise ValueError("'budgets' and 'actuals' must be lists")
 
     logger.info("Reconciling %d budget rows and %d actual rows", len(budgets), len(actuals))
 
-    budget_map: Dict[str, Dict] = {}
+    budget_map: dict[str, dict] = {}
     for b in budgets:
         acct = b.get("account")
         if acct is None:
@@ -50,7 +54,7 @@ def reconcile_budget(data: Dict) -> Dict:
             raise ValueError("Budget row missing 'amount_planned'")
         budget_map[acct] = b
 
-    actual_totals: Dict[str, float] = {}
+    actual_totals: dict[str, float] = {}
     for a in actuals:
         acct = a.get("account")
         if acct is None:
@@ -59,7 +63,7 @@ def reconcile_budget(data: Dict) -> Dict:
             raise ValueError("Actual row missing 'amount_actual'")
         actual_totals[acct] = actual_totals.get(acct, 0.0) + float(a.get("amount_actual", 0.0))
 
-    variance_rows: List[Dict] = []
+    variance_rows: List[dict] = []
 
     processed_accounts = set()
 

--- a/app/data/azure_sql.py
+++ b/app/data/azure_sql.py
@@ -20,7 +20,11 @@ from app.storage import db, models
 logger = logging.getLogger(__name__)
 
 
-@mcp_tool("fetchBudgetData")
+@mcp_tool(
+    name="fetchBudgetData",
+    description="Load budget, actual and transaction data for the given fiscal period",
+    annotations={"readOnlyHint": True},
+)
 def fetch_budget_data(period: str, config_uri: str = "resource://config/azure_sql") -> dict:
     """Return budget and actual data for ``period`` using ``config_uri``.
 

--- a/app/data/variance_excel.py
+++ b/app/data/variance_excel.py
@@ -37,7 +37,11 @@ PROMPT = load_prompt("variance_ingest")
 
 
 
-@mcp.tool(name="parseVarianceSpreadsheet")
+@mcp.tool(
+    name="parseVarianceSpreadsheet",
+    description="Parse a variance spreadsheet into normalized rows",
+    annotations={"readOnlyHint": True},
+)
 def parse_variance(file_path: str) -> List[Dict]:
     """Parse a variance spreadsheet and return rows as dictionaries."""
     path = Path(file_path)

--- a/app/server.py
+++ b/app/server.py
@@ -13,11 +13,14 @@ from fastmcp.prompts.prompt import PromptMessage
 from app.prompts.load import load_prompt_template
 
 from app.data.azure_sql import fetch_budget_data
+from app.analysis.variance import reconcile_budget
+from app.data.variance_excel import parse_variance
 from app.resources.load import resolve_resource
 
 capabilities = {
     "resources": {"listChanged": False, "subscribe": False},
     "prompts": {"listChanged": False},
+    "tools": {"listChanged": False},
 }
 
 mcp = FastMCP()
@@ -29,6 +32,25 @@ if registration:
 else:
     tool = Tool.from_function(fetch_budget_data)
 
+mcp.add_tool(tool)
+
+# Register parse_variance tool
+registration = getattr(parse_variance, "_mcp_tool_registration", {})
+if isinstance(parse_variance, Tool):
+    mcp.add_tool(parse_variance)
+else:
+    if registration:
+        tool = Tool.from_function(parse_variance, **registration)
+    else:
+        tool = Tool.from_function(parse_variance)
+    mcp.add_tool(tool)
+
+# Register reconcile_budget tool
+registration = getattr(reconcile_budget, "_mcp_tool_registration", {})
+if registration:
+    tool = Tool.from_function(reconcile_budget, **registration)
+else:
+    tool = Tool.from_function(reconcile_budget)
 mcp.add_tool(tool)
 
 

--- a/tests/tools/test_discovery.py
+++ b/tests/tools/test_discovery.py
@@ -1,0 +1,32 @@
+"""Tests for MCP tool discovery and invocation."""
+
+import asyncio
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from app.server import mcp
+
+
+def test_tools_list() -> None:
+    tools = asyncio.run(mcp._mcp_list_tools())
+    names = {t.name for t in tools}
+    assert "fetchBudgetData" in names
+    assert "reconcileBudgetVsActual" in names
+    assert "parseVarianceSpreadsheet" in names
+    fetch_tool = next(t for t in tools if t.name == "fetchBudgetData")
+    assert fetch_tool.inputSchema["type"] == "object"
+
+
+def test_call_reconcile() -> None:
+    sample = pathlib.Path(__file__).resolve().parents[2] / "samples" / "mock_variance_input.json"
+    with open(sample) as fh:
+        data = json.load(fh)
+
+    result = asyncio.run(
+        mcp._mcp_call_tool("reconcileBudgetVsActual", {"data": data})
+    )
+    assert result[0].text.startswith("{")
+


### PR DESCRIPTION
## Summary
- register variance and reconciliation tools on the FastMCP server
- describe tools with annotations for read-only behavior
- advertise tool capability in server
- add tests for tool discovery and calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0ac1ff9883269838db279941b030